### PR TITLE
feat: add proper pointer logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,22 +8,32 @@ import Worker from './src/worker.js';
 
 await Actor.init();
 
+const SYNC_TOKEN_KEY = 'ashbyCandidateSyncToken';
+
 // Initialize state values
 const input = await Actor.getInput();
 const { startupJobsToken, ashbyToken } = input;
 // Open a named dataset
 const dataset = await Actor.apifyClient.dataset('k76VMuW7xHGMHN911');
+const kv = await Actor.openKeyValueStore();
 
 const worker = await Worker.create(startupJobsToken, ashbyToken);
 log.info('Startup job list done');
+
+let currentSyncToken = await kv.getValue(SYNC_TOKEN_KEY);
+log.info('Loaded Ashby syncToken', { hasToken: !!currentSyncToken });
 
 try {
   const { items: stateRecords } = await dataset.listItems({ limit: 1000, desc: true });
 
   // Initialize values from state
   log.info('Initiate state');
-  const initialRecords = await worker.getNewRecords(stateRecords);
+  const { records: initialRecords, syncToken: nextToken } = await worker.getNewRecords(stateRecords, currentSyncToken);
   await dataset.pushItems(initialRecords);
+  if (nextToken) {
+    await kv.setValue(SYNC_TOKEN_KEY, nextToken);
+    currentSyncToken = nextToken;
+  }
 } catch (err) {
   log.error('Failed to initialize state from records', err);
   throw err;
@@ -53,8 +63,12 @@ try {
 let newRecords = [];
 try {
   log.info('Updating actor state for next runs');
-  newRecords = await worker.getNewRecords(initializedRecords);
+  const { records, syncToken: nextToken } = await worker.getNewRecords(initializedRecords, currentSyncToken);
+  newRecords = records;
   await dataset.pushItems(newRecords);
+  if (nextToken) {
+    await kv.setValue(SYNC_TOKEN_KEY, nextToken);
+  }
 } catch (err) {
   log.error('Failed to update state from records for next runs', err);
   throw err;

--- a/src/ashbyClient.js
+++ b/src/ashbyClient.js
@@ -24,19 +24,49 @@ export default class AshbyClient {
   }
 
   /**
-   * Recursively gets all applicant/jobs records. By default Ashby only provides 100 results per page
-   * @param {string} cursor
-   * @returns {array} applicant/job record
+   * Gets candidate records from Ashby. With a syncToken, returns only candidates created/updated
+   * since the token was issued. Without one, performs a full sync. Returns a fresh syncToken from
+   * the final page so the caller can persist it for the next run.
+   * Falls back to a full sync if the provided syncToken is expired/invalid.
+   * @param {string} [syncToken]
+   * @returns {Promise<{ results: object[], syncToken: string }>}
    */
-  async applicants2JobsList(cursor) {
-    let results = [];
-    const { data } = await api.post(`${this.url}/candidate.list`, cursor ? { cursor } : {}, { headers: { Authorization: `Basic ${this.token}` } });
-    if (data.moreDataAvailable) {
-      results = [...data.results, ...await this.applicants2JobsList(data.nextCursor)];
-    } else {
-      results = [...results, ...data.results];
+  async applicants2JobsList(syncToken) {
+    const headers = { Authorization: `Basic ${this.token}` };
+    const initialBody = syncToken ? { syncToken } : {};
+
+    const { data: firstPage } = await api.post(`${this.url}/candidate.list`, initialBody, { headers });
+
+    if (firstPage.success === false) {
+      if (syncToken && firstPage.errors?.some((e) => String(e).toLowerCase().includes('sync_token'))) {
+        log.warning('Ashby syncToken invalid/expired, falling back to full sync', { errors: firstPage.errors });
+        return this.applicants2JobsList();
+      }
+      
+      throw new Error(`Ashby candidate.list failed: ${JSON.stringify(firstPage.errors)}`);
     }
-    return results;
+
+    let results = [...firstPage.results];
+    let nextCursor = firstPage.nextCursor;
+    let moreDataAvailable = firstPage.moreDataAvailable;
+    let lastSyncToken = firstPage.syncToken;
+
+    while (moreDataAvailable) {
+      // Ashby requires both cursor and the original syncToken on every paginated call within a sync session
+      const pageBody = syncToken ? { cursor: nextCursor, syncToken } : { cursor: nextCursor };
+      const { data: page } = await api.post(`${this.url}/candidate.list`, pageBody, { headers });
+
+      if (page.success === false) {
+        throw new Error(`Ashby candidate.list pagination failed: ${JSON.stringify(page.errors)}`);
+      }
+
+      results = [...results, ...page.results];
+      nextCursor = page.nextCursor;
+      moreDataAvailable = page.moreDataAvailable;
+      lastSyncToken = page.syncToken || lastSyncToken;
+    }
+
+    return { results, syncToken: lastSyncToken };
   }
 
   /**

--- a/src/worker.js
+++ b/src/worker.js
@@ -38,27 +38,27 @@ export default class Worker {
   }
 
   /**
-   * Gets new records from jazzHR that are not saved in dataset yet
+   * Gets candidate records from Ashby that are not saved in dataset yet.
+   * Uses an Ashby syncToken when provided so subsequent runs only fetch deltas.
    * @param {array} existingRecords
-   * @returns {array} new records
+   * @param {string} [syncToken]
+   * @returns {Promise<{ records: object[], syncToken: string }>}
    */
-  async getNewRecords(existingRecords) {
-    // Get all applicants/jobs records from jazzHR
-    const applicants2Jobs = await this.jazzHR.applicants2JobsList();
-    // Filter those that are new from last actor run
+  async getNewRecords(existingRecords, syncToken) {
+    const { results: applicants2Jobs, syncToken: newSyncToken } = await this.jazzHR.applicants2JobsList(syncToken);
     const newApplicants2Jobs = applicants2Jobs.filter((record) => !existingRecords.find((existingRecord) => existingRecord.id === record.id));
-    // Get details for new applicants from jazzHR
 
-    log.info('newApplicationsDetails');
+    log.info('newApplicationsDetails', { fetched: applicants2Jobs.length, newSinceDataset: newApplicants2Jobs.length });
 
-    // Updated current map of email/job pair
-    return newApplicants2Jobs.map((record) => ({
+    const records = newApplicants2Jobs.map((record) => ({
       id: record.id,
       applyDate: record.createdAt,
       email: record.primaryEmailAddress?.value,
       source: record.source?.id,
       jazzHrApplicationId: record.applicationIds[0],
     }));
+
+    return { records, syncToken: newSyncToken };
   }
 
   /**


### PR DESCRIPTION
## What was wrong

The actor's daily run was timing out (recently bumped from 30 min to 1 h, still failing). Each run called Ashby's `candidate.list` and walked **every** candidate ever (now ~22,000), 100 per page, twice per run — once to seed state, once to update it. With Ashby's pagination slowing as it goes deeper, the two full scans alone consumed 35–60 min, leaving no headroom for a 502 retry to push it past the timeout.

The pagination cursor is session-bound, so it can't be reused between runs to avoid the rescan.

## The fix
Switch to Ashby's `syncToken` for incremental sync on `candidate.list`:

- First run does one full scan and saves the returned `syncToken` to the actor's key-value store.
- Subsequent runs send the saved token; Ashby returns only candidates created/updated since — typically a handful per day instead of 22k.
- If the token is rejected (`sync_token_expired`), the client transparently falls back to a full sync and saves a fresh token.

## Expected impact
Daily runs should drop from 35–60 minutes to a few seconds on the Ashby side, since we'll only fetch the handful of candidates that actually changed since the last run instead of all ~22,000.

Two things to know:
- The first run after deploy still does one full sync (~37 min) to obtain the initial token.
- If the actor is idle for more than ~7 days the token expires; the client detects this and automatically falls back to a full sync, so no manual recovery is needed.